### PR TITLE
fix AddMonths for invalid year calculation

### DIFF
--- a/util.go
+++ b/util.go
@@ -34,7 +34,7 @@ func (d Date) AddDate(year, month, day int) Date {
 func (d Date) AddMonths(n int) Date {
 	year, month, day := d.YMD()
 	iMonth := int(month) + n
-	if iMonth <= 0 {
+	if iMonth <= _monthsOfYear {
 		iMonth -= _monthsOfYear
 	}
 	year += iMonth / _monthsOfYear


### PR DESCRIPTION
If adding months to a date, for example:

testDate := gDate.NewDate(2022, 7, 1)
newDate := testDate.AddMonths(5)

Should return 2022-12-01

However it returns 2023-12-01

This patch makes sure that it gets the proper year