### PR TITLE
fix AddMonths for invalid year calculation

### DIFF
--- a/util.go
+++ b/util.go
@@ -34,10 +34,9 @@ func (d Date) AddDate(year, month, day int) Date {
 func (d Date) AddMonths(n int) Date {
 	year, month, day := d.YMD()
 	iMonth := int(month) + n
-	if iMonth <= 0 {
-		iMonth -= _monthsOfYear
+	if iMonth > _monthsOfYear {
+		year += iMonth / _monthsOfYear
 	}
-	year += iMonth / _monthsOfYear
 	// This formula to calculate the new month both case n > 0 and n < 0
 	// iMonth%_monthsOfYear -> Move the negative value to [-11..0]
 	// + _monthsOfYear -> Make sure positive


### PR DESCRIPTION
If you call AddMonths it sometimes calculates the year incorrectly

For example:

testDate := gDate.NewDate(2022, 7, 1)
newDate := testDate.AddMonths(5)

Returns => 2023-12-01

Should return => 2022-12-01

This patch fixes this year calculation